### PR TITLE
Path error win10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ out
 node_modules
 .vscode-test/
 *.vsix
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "vscode-test": "^1.0.2"
   },
   "dependencies": {
-    "dir-compare": "^1.7.3",
+    "dir-compare": "^1.8.0",
     "lodash": "^4.17.15",
     "text-diff": "^1.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,28 @@
   ],
   "main": "./out/extension.js",
   "contributes": {
+    "configuration": {
+      "type": "object",
+      "title": "Compare Folders Configuration",
+      "properties": {
+        "compare.folders.options.compareContent": {
+          "type": "boolean",
+          "default": true,
+          "description": "Compare content",
+          "scope": "resource"
+        },
+        "compare.folders.options.includeFilter": {
+          "type": "array",
+          "description": "Include filters",
+          "scope": "resource"
+        },
+        "compare.folders.options.excludeFilter": {
+          "type": "array",
+          "description": "Exclude filters",
+          "scope": "resource"
+        }
+      }
+    },
     "menus": {
       "commandPalette": [
         {

--- a/src/providers/foldersCompareProvider.ts
+++ b/src/providers/foldersCompareProvider.ts
@@ -8,6 +8,7 @@ import { getComparedPath } from '../context/path';
 import { getRelativePath } from '../utils/path';
 import { MORE_INFO } from '../constants/windowInformationResult';
 import { ViewOnlyProvider } from './viewOnlyProvider';
+import { Options } from 'dir-compare';
 
 export class CompareFoldersProvider implements TreeDataProvider<File> {
   private _onDidChangeTreeData: EventEmitter<any | undefined> = new EventEmitter<any | undefined>();
@@ -27,7 +28,17 @@ export class CompareFoldersProvider implements TreeDataProvider<File> {
       location: ProgressLocation.Notification,
       title: `Compare folders...`
     }, async () => {
-      const diffs = await chooseFoldersAndCompare(await this.getWorkspaceFolder());
+      const conf = workspace.getConfiguration('compare.folders.options');
+      // Use string array instead of comma separated list of exclude filters
+      const excludeFilterArray = <string[] | undefined> conf.get('excludeFilter');
+      // Use string array instead of comma separated list of include filters
+      const includeFilterArray = <string[] | undefined> conf.get('includeFilter');
+      const options: Options = {
+        compareContent: conf.get('compareContent'),
+        excludeFilter: excludeFilterArray?.join(','),
+        includeFilter: includeFilterArray?.join(','),
+      };
+      const diffs = await chooseFoldersAndCompare(await this.getWorkspaceFolder(), options);
       if (!diffs) {
         return;
       }

--- a/src/providers/foldersCompareProvider.ts
+++ b/src/providers/foldersCompareProvider.ts
@@ -1,7 +1,7 @@
 import { TreeItemCollapsibleState, TreeDataProvider, EventEmitter, Event, TreeItem, commands, workspace, window, WorkspaceFolder } from 'vscode';
 import * as path from 'path';
 import { CHOOSE_FOLDERS_AND_COMPARE, GO_TO_NOTICE } from '../constants/commands';
-import { chooseFoldersAndCompare, showDiffs, compare, CompareResult, showFile } from '../services/comparer';
+import { chooseFoldersAndCompare, showDiffs, compareFolders, CompareResult, showFile } from '../services/comparer';
 import { File } from '../models/file';
 import { build } from '../services/tree-builder';
 import { getComparedPath } from '../context/path';
@@ -19,7 +19,7 @@ export class CompareFoldersProvider implements TreeDataProvider<File> {
   private workspaceRoot: string;
 
   constructor(private onlyInA: ViewOnlyProvider, private onlyInB: ViewOnlyProvider) {
-    this.workspaceRoot = workspace.workspaceFolders ? workspace.workspaceFolders[0].uri.path : '';
+    this.workspaceRoot = workspace.workspaceFolders ? workspace.workspaceFolders[0].uri.fsPath : '';
   }
 
 	chooseFoldersAndCompare = async () => {
@@ -88,9 +88,9 @@ export class CompareFoldersProvider implements TreeDataProvider<File> {
     }
   }
 
-	refresh = (): void => {
+	refresh = async () => {
     try {
-      this._diffs = compare(this.workspaceRoot, getComparedPath());
+      this._diffs = await compareFolders(this.workspaceRoot, getComparedPath());
       if (this._diffs.hasResult()) {
         window.showInformationMessage('Source refreshed', 'Dismiss');
       }

--- a/src/providers/foldersCompareProvider.ts
+++ b/src/providers/foldersCompareProvider.ts
@@ -1,4 +1,4 @@
-import { TreeItemCollapsibleState, TreeDataProvider, EventEmitter, Event, TreeItem, commands, workspace, window, WorkspaceFolder } from 'vscode';
+import { TreeItemCollapsibleState, TreeDataProvider, EventEmitter, Event, TreeItem, commands, workspace, window, WorkspaceFolder, ProgressLocation } from 'vscode';
 import * as path from 'path';
 import { CHOOSE_FOLDERS_AND_COMPARE, GO_TO_NOTICE } from '../constants/commands';
 import { chooseFoldersAndCompare, showDiffs, compareFolders, CompareResult, showFile } from '../services/comparer';
@@ -23,12 +23,17 @@ export class CompareFoldersProvider implements TreeDataProvider<File> {
   }
 
 	chooseFoldersAndCompare = async () => {
-    const diffs = await chooseFoldersAndCompare(await this.getWorkspaceFolder());
-    if (!diffs) {
-      return;
-    }
-    this._diffs = diffs;
-    this.updateUI();
+    await window.withProgress({
+      location: ProgressLocation.Notification,
+      title: `Compare folders...`
+    }, async () => {
+      const diffs = await chooseFoldersAndCompare(await this.getWorkspaceFolder());
+      if (!diffs) {
+        return;
+      }
+      this._diffs = diffs;
+      await this.updateUI();
+    });
   }
 
   getWorkspaceFolder = async () => {

--- a/src/providers/foldersCompareProvider.ts
+++ b/src/providers/foldersCompareProvider.ts
@@ -35,8 +35,8 @@ export class CompareFoldersProvider implements TreeDataProvider<File> {
       const includeFilterArray = <string[] | undefined> conf.get('includeFilter');
       const options: Options = {
         compareContent: conf.get('compareContent'),
-        excludeFilter: excludeFilterArray?.join(','),
-        includeFilter: includeFilterArray?.join(','),
+        excludeFilter: excludeFilterArray ? excludeFilterArray.join(',') : undefined,
+        includeFilter: includeFilterArray ? includeFilterArray.join(',') : undefined,
       };
       const diffs = await chooseFoldersAndCompare(await this.getWorkspaceFolder(), options);
       if (!diffs) {

--- a/src/services/comparer.ts
+++ b/src/services/comparer.ts
@@ -1,5 +1,5 @@
 import { commands, Uri } from 'vscode';
-import { compareSync } from 'dir-compare';
+import { compareSync, compare } from 'dir-compare';
 import { openFolder } from './open-folder';
 import { setComparedPath } from '../context/path';
 
@@ -8,7 +8,7 @@ export async function chooseFoldersAndCompare(path?: string) {
   const folder2Path = await openFolder();
 
   setComparedPath(folder2Path);
-  return compare(folder1Path,  folder2Path);
+  return compareFolders(folder1Path,  folder2Path);
 }
 
 export async function showDiffs([file1, file2]: [string, string], title: string) {
@@ -25,11 +25,11 @@ export async function showFile(file: string, title: string) {
   );
 }
 
-export function compare(folder1Path: string, folder2Path: string): CompareResult {
+export async function compareFolders(folder1Path: string, folder2Path: string): Promise<CompareResult> {
   // compare folders by contents
   const options = {compareContent: true};
   // do the compare
-  const res = compareSync(
+  const res = await compare(
     folder1Path,
     folder2Path,
     options

--- a/src/services/comparer.ts
+++ b/src/services/comparer.ts
@@ -1,14 +1,14 @@
 import { commands, Uri } from 'vscode';
-import { compareSync, compare } from 'dir-compare';
+import { compareSync, compare, Options } from 'dir-compare';
 import { openFolder } from './open-folder';
 import { setComparedPath } from '../context/path';
 
-export async function chooseFoldersAndCompare(path?: string) {
+export async function chooseFoldersAndCompare(path?: string, options?: Options) {
   const folder1Path: string = path || await openFolder();
   const folder2Path = await openFolder();
 
   setComparedPath(folder2Path);
-  return compareFolders(folder1Path,  folder2Path);
+  return compareFolders(folder1Path, folder2Path, options);
 }
 
 export async function showDiffs([file1, file2]: [string, string], title: string) {
@@ -25,14 +25,14 @@ export async function showFile(file: string, title: string) {
   );
 }
 
-export async function compareFolders(folder1Path: string, folder2Path: string): Promise<CompareResult> {
+export async function compareFolders(folder1Path: string, folder2Path: string, options?: Options): Promise<CompareResult> {
   // compare folders by contents
-  const options = {compareContent: true};
+  const concatenatedOptions = {compareContent: true, ...options};
   // do the compare
   const res = await compare(
     folder1Path,
     folder2Path,
-    options
+    concatenatedOptions
   );
 
   // get the diffs

--- a/src/services/comparer.ts
+++ b/src/services/comparer.ts
@@ -2,6 +2,7 @@ import { commands, Uri } from 'vscode';
 import { compareSync, compare, Options } from 'dir-compare';
 import { openFolder } from './open-folder';
 import { setComparedPath } from '../context/path';
+import * as path from 'path';
 
 export async function chooseFoldersAndCompare(path?: string, options?: Options) {
   const folder1Path: string = path || await openFolder();
@@ -42,18 +43,18 @@ export async function compareFolders(folder1Path: string, folder2Path: string, o
   const distinct = diffSet
     .filter(diff => diff.state === 'distinct')
     .map(diff => [
-      fixDoubleSlash(`${diff.path1}/${diff.name1}`),
-      fixDoubleSlash(`${diff.path2}/${diff.name2}`)
+      path.join(diff.path1!, diff.name1!),
+      path.join(diff.path2!, diff.name2!)
     ]);
 
   // readable 👍 performance 👎
   const left = diffSet
     .filter(diff => diff.state === 'left' && diff.type1 === 'file')
-    .map(diff => [fixDoubleSlash(`${diff.path1}/${diff.name1}`)]);
+    .map(diff => [path.join(diff.path1!, diff.name1!)]);
 
   const right = diffSet
     .filter(diff => diff.state === 'right' && diff.type2 === 'file')
-    .map(diff => [fixDoubleSlash(`${diff.path2}/${diff.name2}`)]);
+    .map(diff => [path.join(diff.path2!, diff.name2!)]);
 
   return new CompareResult(
     distinct,
@@ -64,9 +65,6 @@ export async function compareFolders(folder1Path: string, folder2Path: string, o
   );
 }
 
-function fixDoubleSlash(str: string) {
-  return str.replace('//', '/');
-}
 
 export class CompareResult {
   constructor(

--- a/src/services/tree-builder.ts
+++ b/src/services/tree-builder.ts
@@ -2,16 +2,17 @@ import { TreeItemCollapsibleState } from 'vscode';
 import set from 'lodash/set';
 import { COMPARE_FILES } from '../constants/commands';
 import { File } from '../models/file';
+import * as path from 'path';
 
 type AnonymusObject = {[key: string]: AnonymusObject | Array<any> };
 
 export function build(paths: string[][], basePath: string) {
   const tree = {};
-  paths.forEach(path => {
-    const relativePath = path[0].replace(`${basePath}/`, '');
-    const segments = relativePath.split('/');
+  paths.forEach(filePath => {
+    const relativePath = path.relative(basePath, filePath[0]);
+    const segments = relativePath.split(path.sep);
 
-    set(tree, segments, [path, relativePath]);
+    set(tree, segments, [filePath, relativePath]);
   });
 
   const treeItems = createHierarchy(tree);

--- a/src/test/suite/tree-builder.test.ts
+++ b/src/test/suite/tree-builder.test.ts
@@ -3,6 +3,7 @@ import { build } from '../../services/tree-builder';
 import { File } from '../../models/file';
 import { TreeItemCollapsibleState } from 'vscode';
 import { COMPARE_FILES } from '../../constants/commands';
+import * as path from 'path';
 
 suite('Extension Test Suite', () => {
 	test('Generate tree with one file', () => {
@@ -31,7 +32,7 @@ suite('Extension Test Suite', () => {
           folder2: {
             'index.html': [
               paths[0],
-              'folder1/folder2/index.html'
+              path.join('folder1/folder2/index.html')
             ]
           }
         }
@@ -53,7 +54,7 @@ suite('Extension Test Suite', () => {
             new File('index.html', TreeItemCollapsibleState.None, 'file', {
               title: 'index.html',
               command: COMPARE_FILES,
-              arguments: [paths[0], 'folder1/folder2/index.html']
+              arguments: [paths[0], path.join('folder1/folder2/index.html')]
             })
           ])
         ])


### PR DESCRIPTION
It fixes issue #10

- [x] Tree is now well displayed (use path module where possible to fix os specific syntax)
- [x] Add progress bar to wait until it's done
- [x] Add 3 options in settings.json that is related to dir-compare npm module
  - compare.folders.options.includeFilter
  - compare.folders.options.excludeFilter
  - compare.folders.options.compareContent
  
sample: 
```json
"compare.folders.options.excludeFilter": [
"**/node_modules",
"**/.svn",
"**/.git"
]
```