### PR TITLE
Add an option to ignore case

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,12 @@
           "description": "Compare content",
           "scope": "resource"
         },
+        "compareFolders.ignoreFileNameCase": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true fileName / FileName / FiLE naMe will consider as same file and will be compared",
+          "scope": "resource"
+        },
         "compareFolders.includeFilter": {
           "type": "array",
           "description": "Include filters",

--- a/src/services/comparer.ts
+++ b/src/services/comparer.ts
@@ -5,7 +5,7 @@ import { setComparedPath } from '../context/path';
 import * as path from 'path';
 import { getConfiguration } from './configuration';
 
-export async function chooseFoldersAndCompare(path?: string, options?: Options) {
+export async function chooseFoldersAndCompare(path: string, options: Options) {
   const folder1Path: string = path || await openFolder();
   const folder2Path = await openFolder();
 
@@ -43,7 +43,7 @@ export async function showFile(file: string, title: string) {
   );
 }
 
-export async function compareFolders(folder1Path: string, folder2Path: string, options?: Options): Promise<CompareResult> {
+export async function compareFolders(folder1Path: string, folder2Path: string, options: Options): Promise<CompareResult> {
   // compare folders by contents
   const concatenatedOptions = {compareContent: true, ...options};
   // do the compare

--- a/src/services/configuration.ts
+++ b/src/services/configuration.ts
@@ -5,6 +5,7 @@ interface IConfigurations {
   excludeFilter: string[] | undefined;
   includeFilter: string[] | undefined;
   diffViewTitle: 'name only' | 'compared path' | 'full path';
+  ignoreFileNameCase: boolean;
 }
 
 type ConfigurationItem = keyof IConfigurations;


### PR DESCRIPTION
Add an option in settings to ignore case when comparing file names

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/3723951/75522009-8f19d480-5a11-11ea-915c-645e9f369350.gif)

resolve #23 