### PR TITLE
Allow to choose 2 folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Change log
 
+**0.9.0**
+
+Allow to choose 2 folders without having to open one of them as a workspace.
+
+If there is one folder in the workspace, it will compare this with the one the user choose.
+If there are more than one folder, it let's the user to choose one of the folders and then, the a different folder to compare.
+
 **0.8.0**
 
 Allow the change diff view's sides ([#21](https://github.com/moshfeu/vscode-compare-folders/issues/21))

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Visual Studio Marketplace](https://vsmarketplacebadge.apphb.com/installs-short/moshfeu.compare-folders.svg?style=flat-square)](https://marketplace.visualstudio.com/items?itemName=moshfeu.compare-folders)
 [![Follow me on Twitter](https://img.shields.io/twitter/follow/moshfeu.svg?style=social)](https://twitter.com/moshfeu)
 
-The extension allows the user to compare folders, show the diffs in a list and present diff in a splitted view side by side.
+The extension allows you to compare folders, show the diffs in a list and present diff in a splitted view side by side.
 
 ![Screen record](https://user-images.githubusercontent.com/3723951/71845669-7ce67e80-30d1-11ea-8a66-54222a8c628f.gif)
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "compare-folders",
   "displayName": "Compare Folders",
   "description": "Compare folders by contents, present the files that have differences and display the diffs side by side",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/moshfeu/vscode-compare-folders"
@@ -140,18 +140,15 @@
       "foldersCompare": [
         {
           "id": "foldersCompareAppService",
-          "name": "Differences",
-          "when": "workspaceFolderCount != 0"
+          "name": "Differences"
         },
         {
           "id": "foldersCompareAppServiceOnlyA",
-          "name": "Only in my folder",
-          "when": "workspaceFolderCount != 0"
+          "name": "Only in my folder"
         },
         {
           "id": "foldersCompareAppServiceOnlyB",
-          "name": "Only in compared folder",
-          "when": "workspaceFolderCount != 0"
+          "name": "Only in compared folder"
         }
       ]
     }

--- a/src/context/path.ts
+++ b/src/context/path.ts
@@ -1,9 +1,30 @@
-let comparedPath = '';
+import {workspace} from 'vscode';
 
-export function setComparedPath(path: string): void {
-  comparedPath = path;
+class PathContext {
+  private _mainPath: string | undefined;
+  private _comparedPath: string | undefined;
+
+  get mainPath() {
+    if (!this._mainPath) {
+      return workspace.rootPath ?? '';
+    }
+    return this._mainPath;
+  }
+
+  set mainPath(path: string) {
+    this._mainPath = path;
+  }
+
+  get comparedPath() {
+    if (!this._comparedPath) {
+      throw new Error('compared path is not set');
+    }
+    return this._comparedPath;
+  }
+
+  set comparedPath(path: string) {
+    this._comparedPath = path;
+  }
 }
 
-export function getComparedPath(): string {
-  return comparedPath;
-}
+export const pathContext = new PathContext();

--- a/src/services/comparer.ts
+++ b/src/services/comparer.ts
@@ -1,11 +1,11 @@
 import { commands, Uri } from 'vscode';
 import { compare, Options } from 'dir-compare';
 import { openFolder } from './open-folder';
-import { setComparedPath } from '../context/path';
 import * as path from 'path';
 import { getConfiguration } from './configuration';
+import { pathContext } from '../context/path';
 
-export async function chooseFoldersAndCompare(path: string, options: Options) {
+export async function chooseFoldersAndCompare(options: Options, path?: string) {
   const folder1Path: string = path || await openFolder();
   const folder2Path = await openFolder();
 
@@ -13,7 +13,8 @@ export async function chooseFoldersAndCompare(path: string, options: Options) {
     return;
   }
 
-  setComparedPath(folder2Path);
+  pathContext.mainPath = folder1Path;
+  pathContext.comparedPath = folder2Path;
   return compareFolders(folder1Path, folder2Path, options);
 }
 


### PR DESCRIPTION
It's a start for #26 .
Currently it aims to allow the user to choose 2 folders (when there are no folders in the workspace). Unlike today so the user has to open one folder as a workspace and then choose a folder to compare.

If it goes well, next step will be to allow compare 2 folders in the same project.

I'll be happy to get feedback for this version. You can download it [here](https://github.com/moshfeu/vscode-compare-folders/releases/download/v0.9.0/compare-folders-0.9.0.vsix) or via the release page: https://github.com/moshfeu/vscode-compare-folders/releases/tag/v0.9.0

